### PR TITLE
Add view page on github link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer>
     <div class="container">
         <div class="row p20">
-            <div class="col-md-4 text-center mt25">Site licenced under CC-BY-SA 4.0. Find the code at <a href="https://github.com/leedsraspjam/">https://github.com/leedsraspjam.</a></div>
+            <div class="col-md-4 text-center mt25">Site licenced under CC-BY-SA 4.0. <a href="{{site.github.repository_url}}/blob/master/{{page.path}}">View this page on github</a></div>
             <div class="col-md-4 text-center mt25">
                {% if site.twitter %}
                <a target="_blank" href="{{site.twitter}}"><li class="social twitter"><i class="fa fa-twitter-square"></i></li></a>


### PR DESCRIPTION
I changed the link so it goes straight to the correct page on github. I think this would be better than just linking to the main org page as its more specific. If you don't like it straight away going to that page I could change it so it just goes to the main repo.

Link to issue where I got the code from: https://github.com/jekyll/jekyll-help/issues/5#issuecomment-39033862